### PR TITLE
Fix parsing empty lines and leading/trailing trivias

### DIFF
--- a/Broccolini.Test/ParserTest.cs
+++ b/Broccolini.Test/ParserTest.cs
@@ -37,7 +37,7 @@ public sealed class ParserTest
 
     public static TheoryData<string, string> GetCommentsData()
         => CommentNodes.Select(c => (c, string.Empty))
-            .Concat(CommentNodes.SelectMany(_ => LeadingNodes, ValueTuple.Create))
+            .Concat(CommentNodes.SelectMany(_ => NotEmptyLeadingNodes, ValueTuple.Create))
             .ToTheoryData();
 
     [Theory]
@@ -51,7 +51,7 @@ public sealed class ParserTest
 
     public static TheoryData<string, string> GetGarbageData()
         => GarbageNodes.Select(c => (c, string.Empty))
-            .Concat(GarbageNodes.SelectMany(_ => LeadingNodes, ValueTuple.Create))
+            .Concat(GarbageNodes.SelectMany(_ => NotEmptyLeadingNodes, ValueTuple.Create))
             .ToTheoryData();
 
     [Theory]

--- a/Broccolini.Test/TestData.cs
+++ b/Broccolini.Test/TestData.cs
@@ -18,13 +18,16 @@ internal static class TestData
             "; key = value",
             "; [section]");
 
-    public static IEnumerable<string> LeadingNodes
+    public static IEnumerable<string> NotEmptyLeadingNodes
         => Sequence.Return(
             "; comment\r\n" +
             "garbage\r\n",
             "[section]\r\n",
-            "\r\n",
             "key = value\r\n");
+
+    public static IEnumerable<string> LeadingNodes
+        => NotEmptyLeadingNodes
+            .Append("\r\n");
 
     public static IEnumerable<SectionWithName> SectionsWithNames
         => Sequence.Return(

--- a/Broccolini/Parsing/ParserInputExtensions.cs
+++ b/Broccolini/Parsing/ParserInputExtensions.cs
@@ -12,6 +12,14 @@ internal static class ParserInputExtensions
             : current;
     }
 
+    public static IniToken PeekIgnoreWhitespacesNewLines(this IParserInput input)
+    {
+        var lookAhead = 0;
+        for (; input.Peek(lookAhead) is IniToken.WhiteSpace or IniToken.NewLine; lookAhead++) { }
+
+        return input.Peek(lookAhead);
+    }
+
     public static TToken? ReadOrNull<TToken>(this IParserInput input) where TToken : IniToken => ReadOrNull<TToken>(input, static _ => true);
 
     public static TToken? ReadOrNull<TToken>(this IParserInput input, Func<TToken, bool> predicate)
@@ -29,19 +37,22 @@ internal static class ParserInputExtensions
     }
 
     public static IImmutableList<IniToken> ReadWhile(this IParserInput input, Func<IniToken, bool> predicate)
+        => input.ReadWhile(static input => input.Peek(), (t, _) => predicate(t));
+
+    public static IImmutableList<IniToken> ReadWhile(this IParserInput input, Func<IniToken, IParserInput, bool> predicate)
         => input.ReadWhile(static input => input.Peek(), predicate);
 
     public static IImmutableList<IniToken> ReadWhileExcludeTrailingWhitespace(this IParserInput input, Func<IniToken, bool> predicate)
-        => input.ReadWhile(static input => input.PeekIgnoreWhitespace(), predicate);
+        => input.ReadWhile(static input => input.PeekIgnoreWhitespace(), (t, _) => predicate(t));
 
-    private static IImmutableList<IniToken> ReadWhile(this IParserInput input, Func<IParserInput, IniToken> peek, Func<IniToken, bool> predicate)
+    private static IImmutableList<IniToken> ReadWhile(this IParserInput input, Func<IParserInput, IniToken> peek, Func<IniToken, IParserInput, bool> predicate)
     {
         var tokens = ImmutableArray.CreateBuilder<IniToken>();
 
         while (true)
         {
             var token = peek(input);
-            if (token is IniToken.Epsilon || !predicate(token)) break;
+            if (token is IniToken.Epsilon || !predicate(token, input)) break;
             tokens.Add(input.Read());
         }
 

--- a/Broccolini/PublicAPI.Shipped.txt
+++ b/Broccolini/PublicAPI.Shipped.txt
@@ -8,14 +8,10 @@ Broccolini.IniParser
 Broccolini.SemanticModelExtensions
 Broccolini.Syntax.CommentIniNode
 Broccolini.Syntax.CommentIniNode.CommentIniNode(string! text) -> void
-Broccolini.Syntax.CommentIniNode.LeadingTrivia.get -> Broccolini.Syntax.IniToken.WhiteSpace?
-Broccolini.Syntax.CommentIniNode.LeadingTrivia.init -> void
 Broccolini.Syntax.CommentIniNode.Semicolon.get -> Broccolini.Syntax.IniToken.Semicolon!
 Broccolini.Syntax.CommentIniNode.Semicolon.init -> void
 Broccolini.Syntax.CommentIniNode.Text.get -> string!
 Broccolini.Syntax.CommentIniNode.Text.init -> void
-Broccolini.Syntax.CommentIniNode.TrailingTrivia.get -> Broccolini.Syntax.IniToken.WhiteSpace?
-Broccolini.Syntax.CommentIniNode.TrailingTrivia.init -> void
 Broccolini.Syntax.CommentIniNode.TriviaAfterSemicolon.get -> Broccolini.Syntax.IniToken.WhiteSpace?
 Broccolini.Syntax.CommentIniNode.TriviaAfterSemicolon.init -> void
 Broccolini.Syntax.IIniNodeVisitor
@@ -31,6 +27,10 @@ Broccolini.Syntax.IniDocument.Sections.get -> System.Collections.Immutable.IImmu
 Broccolini.Syntax.IniDocument.Sections.init -> void
 Broccolini.Syntax.IniNode
 Broccolini.Syntax.IniNode.IniNode(Broccolini.Syntax.IniNode! original) -> void
+Broccolini.Syntax.IniNode.LeadingTrivia.get -> System.Collections.Immutable.IImmutableList<Broccolini.Syntax.IniToken!>!
+Broccolini.Syntax.IniNode.LeadingTrivia.init -> void
+Broccolini.Syntax.IniNode.TrailingTrivia.get -> System.Collections.Immutable.IImmutableList<Broccolini.Syntax.IniToken!>!
+Broccolini.Syntax.IniNode.TrailingTrivia.init -> void
 Broccolini.Syntax.IniNode.NewLine.get -> Broccolini.Syntax.IniToken.NewLine?
 Broccolini.Syntax.IniNode.NewLine.init -> void
 Broccolini.Syntax.IniSyntaxFactory
@@ -59,12 +59,8 @@ Broccolini.Syntax.KeyValueIniNode.EqualsSign.init -> void
 Broccolini.Syntax.KeyValueIniNode.Key.get -> string!
 Broccolini.Syntax.KeyValueIniNode.Key.init -> void
 Broccolini.Syntax.KeyValueIniNode.KeyValueIniNode(string! key, string! value) -> void
-Broccolini.Syntax.KeyValueIniNode.LeadingTrivia.get -> Broccolini.Syntax.IniToken.WhiteSpace?
-Broccolini.Syntax.KeyValueIniNode.LeadingTrivia.init -> void
 Broccolini.Syntax.KeyValueIniNode.Quote.get -> Broccolini.Syntax.IniToken.Quote?
 Broccolini.Syntax.KeyValueIniNode.Quote.init -> void
-Broccolini.Syntax.KeyValueIniNode.TrailingTrivia.get -> Broccolini.Syntax.IniToken.WhiteSpace?
-Broccolini.Syntax.KeyValueIniNode.TrailingTrivia.init -> void
 Broccolini.Syntax.KeyValueIniNode.TriviaAfterEqualsSign.get -> Broccolini.Syntax.IniToken.WhiteSpace?
 Broccolini.Syntax.KeyValueIniNode.TriviaAfterEqualsSign.init -> void
 Broccolini.Syntax.KeyValueIniNode.TriviaBeforeEqualsSign.get -> Broccolini.Syntax.IniToken.WhiteSpace?
@@ -79,15 +75,11 @@ Broccolini.Syntax.SectionIniNode.Children.init -> void
 Broccolini.Syntax.SectionIniNode.ClosingBracket.get -> Broccolini.Syntax.IniToken.ClosingBracket?
 Broccolini.Syntax.SectionIniNode.ClosingBracket.init -> void
 Broccolini.Syntax.SectionIniNode.Equals(Broccolini.Syntax.SectionIniNode? other) -> bool
-Broccolini.Syntax.SectionIniNode.LeadingTrivia.get -> Broccolini.Syntax.IniToken.WhiteSpace?
-Broccolini.Syntax.SectionIniNode.LeadingTrivia.init -> void
 Broccolini.Syntax.SectionIniNode.Name.get -> string!
 Broccolini.Syntax.SectionIniNode.Name.init -> void
 Broccolini.Syntax.SectionIniNode.OpeningBracket.get -> Broccolini.Syntax.IniToken.OpeningBracket!
 Broccolini.Syntax.SectionIniNode.OpeningBracket.init -> void
 Broccolini.Syntax.SectionIniNode.SectionIniNode(string! name, System.Collections.Immutable.IImmutableList<Broccolini.Syntax.SectionChildIniNode!>! children) -> void
-Broccolini.Syntax.SectionIniNode.TrailingTrivia.get -> System.Collections.Immutable.IImmutableList<Broccolini.Syntax.IniToken!>!
-Broccolini.Syntax.SectionIniNode.TrailingTrivia.init -> void
 Broccolini.Syntax.SectionIniNode.TriviaAfterOpeningBracket.get -> Broccolini.Syntax.IniToken.WhiteSpace?
 Broccolini.Syntax.SectionIniNode.TriviaAfterOpeningBracket.init -> void
 Broccolini.Syntax.SectionIniNode.TriviaBeforeClosingBracket.get -> Broccolini.Syntax.IniToken.WhiteSpace?

--- a/Broccolini/Syntax/IniDocument.cs
+++ b/Broccolini/Syntax/IniDocument.cs
@@ -48,13 +48,25 @@ public sealed record IniDocument
 [EditorBrowsable(EditorBrowsableState.Advanced)]
 public abstract record IniNode
 {
-    private protected IniNode() { }
+    private protected IniNode()
+    {
+    }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     protected IniNode(IniNode original)
     {
+        LeadingTrivia = original.LeadingTrivia;
+        TrailingTrivia = original.TrailingTrivia;
         NewLine = original.NewLine;
     }
+
+    /// <summary>Leading whitespace.</summary>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public IImmutableList<IniToken> LeadingTrivia { get; init; } = ImmutableArray<IniToken>.Empty;
+
+    /// <summary>Trailing whitespace and garbage after the closing bracket.</summary>
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public IImmutableList<IniToken> TrailingTrivia { get; init; } = ImmutableArray<IniToken>.Empty;
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public IniToken.NewLine? NewLine { get; init; }
@@ -102,9 +114,6 @@ public sealed record KeyValueIniNode : SectionChildIniNode
 
     public string Value { get; init; }
 
-    /// <summary>Leading whitespace.</summary>
-    public IniToken.WhiteSpace? LeadingTrivia { get; init; }
-
     /// <summary>Whitespace between key and equals sign.</summary>
     public IniToken.WhiteSpace? TriviaBeforeEqualsSign { get; init; }
 
@@ -115,9 +124,6 @@ public sealed record KeyValueIniNode : SectionChildIniNode
 
     /// <summary>Opening and closing quote when value is quoted.</summary>
     public IniToken.Quote? Quote { get; init; }
-
-    /// <summary>Whitespace after value.</summary>
-    public IniToken.WhiteSpace? TrailingTrivia { get; init; }
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public override void Accept(IIniNodeVisitor visitor) => visitor.Visit(this);
@@ -172,16 +178,10 @@ public sealed record CommentIniNode : SectionChildIniNode
 
     public string Text { get; init; }
 
-    /// <summary>Leading whitespace.</summary>
-    public IniToken.WhiteSpace? LeadingTrivia { get; init; }
-
     public IniToken.Semicolon Semicolon { get; init; } = new();
 
     /// <summary>Whitespace between semicolon and text.</summary>
     public IniToken.WhiteSpace? TriviaAfterSemicolon { get; init; }
-
-    /// <summary>Trailing whitespace.</summary>
-    public IniToken.WhiteSpace? TrailingTrivia { get; init; }
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public override void Accept(IIniNodeVisitor visitor) => visitor.Visit(this);
@@ -212,10 +212,6 @@ public sealed record SectionIniNode : IniNode
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public IImmutableList<SectionChildIniNode> Children { get; init; }
 
-    /// <summary>Leading whitespace.</summary>
-    [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public IniToken.WhiteSpace? LeadingTrivia { get; init; }
-
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public IniToken.OpeningBracket OpeningBracket { get; init; } = new();
 
@@ -230,10 +226,6 @@ public sealed record SectionIniNode : IniNode
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public IniToken.ClosingBracket? ClosingBracket { get; init; } = new();
 
-    /// <summary>Trailing whitespace and garbage after the closing bracket.</summary>
-    [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public IImmutableList<IniToken> TrailingTrivia { get; init; } = ImmutableArray<IniToken>.Empty;
-
     internal IniToken.NewLine? NewLineHint { get; init; }
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -246,7 +238,7 @@ public sealed record SectionIniNode : IniNode
         => other is not null
            && Name == other.Name
            && Children.SequenceEqual(other.Children)
-           && LeadingTrivia == other.LeadingTrivia
+           && LeadingTrivia.SequenceEqual(other.LeadingTrivia)
            && OpeningBracket == other.OpeningBracket
            && TriviaAfterOpeningBracket == other.TriviaAfterOpeningBracket
            && TriviaBeforeClosingBracket == other.TriviaBeforeClosingBracket

--- a/Broccolini/Syntax/ToStringVisitor.cs
+++ b/Broccolini/Syntax/ToStringVisitor.cs
@@ -18,7 +18,7 @@ internal sealed class ToStringVisitor : IIniNodeVisitor
 
     public void Visit(KeyValueIniNode keyValueNode)
     {
-        VisitToken(keyValueNode.LeadingTrivia);
+        VisitTokens(keyValueNode.LeadingTrivia);
         _stringBuilder.Append(keyValueNode.Key);
         VisitToken(keyValueNode.TriviaBeforeEqualsSign);
         _stringBuilder.Append(keyValueNode.EqualsSign);
@@ -26,19 +26,21 @@ internal sealed class ToStringVisitor : IIniNodeVisitor
         VisitToken(keyValueNode.Quote);
         _stringBuilder.Append(keyValueNode.Value);
         VisitToken(keyValueNode.Quote);
-        VisitToken(keyValueNode.TrailingTrivia);
+        VisitTokens(keyValueNode.TrailingTrivia);
         VisitToken(keyValueNode.NewLine);
     }
 
     public void Visit(UnrecognizedIniNode triviaNode)
     {
+        VisitTokens(triviaNode.LeadingTrivia);
         VisitTokens(triviaNode.Tokens);
         VisitToken(triviaNode.NewLine);
+        VisitTokens(triviaNode.TrailingTrivia);
     }
 
     public void Visit(SectionIniNode sectionNode)
     {
-        VisitToken(sectionNode.LeadingTrivia);
+        VisitTokens(sectionNode.LeadingTrivia);
         _stringBuilder.Append(sectionNode.OpeningBracket);
         VisitToken(sectionNode.TriviaAfterOpeningBracket);
         _stringBuilder.Append(sectionNode.Name);
@@ -51,11 +53,11 @@ internal sealed class ToStringVisitor : IIniNodeVisitor
 
     public void Visit(CommentIniNode commentNode)
     {
-        VisitToken(commentNode.LeadingTrivia);
+        VisitTokens(commentNode.LeadingTrivia);
         VisitToken(commentNode.Semicolon);
         VisitToken(commentNode.TriviaAfterSemicolon);
         _stringBuilder.Append(commentNode.Text);
-        VisitToken(commentNode.TrailingTrivia);
+        VisitTokens(commentNode.TrailingTrivia);
         VisitToken(commentNode.NewLine);
     }
 


### PR DESCRIPTION
-Empty lines are recognized as leading or trailing trivia
-Every node can have leading/trailing trivia

Notice: IsBlank is still a valid function, an only-whitespace document contains a single "blank" UnrecognizedNode.